### PR TITLE
Fix error handling when font files are missing

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -124,7 +124,7 @@ class TestPreviewCommandErrors:
         result = runner.invoke(cli, ["preview", "--manifest", str(manifest)])
 
         assert result.exit_code == 1
-        assert "No PCF or BDF files found" in result.output
+        assert "not found on disk" in result.output
 
     def test_preview_font_file_not_exists(self, runner: CliRunner, tmp_path: Path):
         """Test error when font file referenced in manifest doesn't exist."""
@@ -139,7 +139,7 @@ class TestPreviewCommandErrors:
         result = runner.invoke(cli, ["preview", "--manifest", str(manifest)])
 
         assert result.exit_code == 1
-        assert "Font file not found" in result.output
+        assert "not found on disk" in result.output
 
 
 class TestPreviewCommandLogic:


### PR DESCRIPTION
## Summary
Fixes #2 - Improve error handling when manifest has no usable font files.

## Problem
When a manifest exists but has no font files (e.g., `generated_files: []` from failed generation), the CLI would print an error but pygame would still initialize, showing confusing warnings mixed with the error message.

## Solution
Added validation helper function that checks manifest quality before preview runs:
- `validate_manifest_for_preview()` in `manifest.py`
- Validates early, before any pygame initialization
- Returns clear, contextual error messages

## Changes

### New Validation Function (`manifest.py`)
- Checks if `generated_files` list exists and is not empty
- Checks if listed font files actually exist on disk
- Distinguishes between the two error cases
- Returns detailed error messages with manifest path

### Updated CLI (`cli.py`)
- Calls validation immediately after loading manifest
- Simplified font file selection logic (prefer PCF over BDF)
- Removed duplicate validation checks
- Cleaner error handling flow

### Better Error Messages
**Before:**
```
Error: No font files found in manifest
```

**After:**
```
Error: No font files found in manifest: /path/to/icons-manifest.json
  Manifest has empty generated_files list
  Font generation may have failed - check cp-font-gen output
```

### Testing
- Added 6 comprehensive tests for validation function
- Updated 2 existing CLI tests for new error messages
- All 43 tests passing

## Testing
Tested with:
- ✅ Icons manifest (empty `generated_files`)
- ✅ Valid manifests (minimal, emoji, menu, multilingual, temperature)
- ✅ Missing files on disk scenario
- ✅ All existing functionality preserved

## Architecture Benefits
- Clean separation of validation logic (no pygame dependencies)
- Easily testable validation function
- Better error messages for users
- Validation happens early in the flow

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>